### PR TITLE
Rewrite examples/CLAUDE.md with realistic MCP server project

### DIFF
--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -1,65 +1,70 @@
 # CLAUDE.md
 
-<!-- This is a template for your project's CLAUDE.md file.
-     The claude-workflows automation reads this file to understand your project's
-     conventions, tooling, and testing procedures. Fill in each section below
-     and delete the HTML comments when you're done. -->
-
 ## Project Overview
 
-<!-- Brief description of what this project does, its tech stack, and architecture.
-     Example:
-     This is a Go + React monorepo for an internal billing service.
-     Backend lives in cmd/ and pkg/, frontend in web/. -->
+`findata-mcp` is a Rust MCP (Model Context Protocol) server that provides semantic Q&A over US company financials and macroeconomic data. It ingests SEC filings (10-K, 10-Q, 8-K), earnings transcripts, and macro indicators (unemployment, CPI, GDP) into a Qdrant vector database, enabling LLMs to answer natural-language questions about financial data via MCP tools.
+
+**Tech stack**: Rust (2024 edition), Qdrant (vector DB), Nomic Embed v1.5 (embedding model served locally), Docker Compose.
+
+**Repo layout**:
+- `src/` — MCP server, tool handlers, ingestion pipeline, embedding client
+- `src/tools/` — MCP tool implementations (`financials.rs`, `macro_indicators.rs`, `search.rs`)
+- `src/ingest/` — SEC EDGAR and FRED data ingestion (`edgar.rs`, `fred.rs`, `chunker.rs`)
+- `src/embed/` — Embedding client that calls the local Nomic container (`client.rs`, `batch.rs`)
+- `tests/` — Integration tests (require Docker Compose services running)
+- `docker/` — Dockerfiles for the MCP server and embedding service
+- `docker-compose.yml` — Qdrant, Nomic Embed service, and the MCP server
 
 ## Implementation Workflow
 
-<!-- Step-by-step guide for implementing a feature from an issue.
-     The implement workflows (claude-dev-loop, claude-issue-implement) follow these steps.
-     Example:
-     1. Read the issue spec carefully
-     2. Create a feature branch: git checkout -b feature/issue-<N>-<slug>
-     3. Implement the changes following the spec
-     4. Run quality checks (see below)
-     5. Commit with a descriptive message referencing the issue
-     6. Push and create a PR -->
+1. Read the issue spec carefully — understand which MCP tools, ingestion sources, or API endpoints are affected
+2. Create a feature branch: `git checkout -b feature/issue-<N>-<slug>`
+3. Implement changes following the spec:
+   - New MCP tools go in `src/tools/` and must be registered in `src/tools/mod.rs`
+   - Ingestion changes go in `src/ingest/`; always handle rate limits for external APIs (EDGAR, FRED)
+   - Use the `EmbedClient` from `src/embed/client.rs` for all vectorization — never call the embedding service directly
+4. Run quality checks (see below)
+5. Run E2E tests against Docker Compose (see below)
+6. Commit with a descriptive message referencing the issue
+7. Push and create a PR: `gh pr create --fill`
 
 ## Quality Checks
 
-<!-- Commands for formatting, linting, and testing.
-     The fix-iteration workflow runs these after addressing review feedback.
-     Example:
-     - Format: `go fmt ./...` and `cd web && npm run format`
-     - Lint: `golangci-lint run` and `cd web && npm run lint`
-     - Test: `go test ./...` and `cd web && npm test` -->
+- **Format**: `cargo fmt --all --check`
+- **Lint**: `cargo clippy --workspace --all-targets -- -D warnings`
+- **Unit tests**: `cargo test --workspace`
+
+Run all three before pushing. The CI pipeline will reject PRs that fail any of these.
 
 ## E2E Testing
 
-<!-- Build, deploy, and test procedures for end-to-end validation.
-     The implement and fix workflows run these after code changes.
-     Example:
-     1. Build: `docker compose build`
-     2. Deploy: `docker compose up -d`
-     3. Wait for health: `curl --retry 10 --retry-delay 2 http://localhost:8080/health`
-     4. Run e2e tests: `npm run test:e2e`
-     5. Teardown: `docker compose down` -->
+1. Build all containers: `docker compose build`
+2. Start services: `docker compose up -d`
+3. Wait for Qdrant: `curl --retry 10 --retry-delay 3 --retry-all-errors http://localhost:6333/healthz`
+4. Wait for embedding service: `curl --retry 10 --retry-delay 3 --retry-all-errors http://localhost:8090/health`
+5. Wait for MCP server: `curl --retry 10 --retry-delay 3 --retry-all-errors http://localhost:3000/health`
+6. Run integration tests: `cargo test --test integration -- --test-threads=1`
+7. Teardown: `docker compose down -v`
 
 ## Environment
 
-<!-- Environment variables, server addresses, database details, and credentials access.
-     The implement and researcher workflows reference this for deployment and testing.
-     Example:
-     - DATABASE_URL: postgres://localhost:5432/myapp_dev
-     - API_BASE_URL: http://localhost:8080
-     - Secrets are in 1Password vault "Engineering" -->
+- `QDRANT_URL`: `http://localhost:6333` — Qdrant gRPC is on `localhost:6334`
+- `EMBED_SERVICE_URL`: `http://localhost:8090` — local Nomic Embed v1.5 container
+- `MCP_SERVER_PORT`: `3000`
+- `EDGAR_USER_AGENT`: required by SEC EDGAR fair access policy (set to `findata-mcp team@example.com`)
+- `FRED_API_KEY`: API key for FRED (Federal Reserve Economic Data); obtain a free key at https://fred.stlouisfed.org/docs/api/api_key.html
+- `RUST_LOG`: `info` by default; set to `debug` for verbose output
+- Secrets are in 1Password vault "findata-mcp Dev"
 
 ## Code Quality Scoring
 
-<!-- Scoring rubric and categories used during code review.
-     The review-iteration workflow uses this to evaluate PR quality.
-     Example:
-     Reviews are scored on: correctness, test coverage, error handling,
-     performance, and adherence to project conventions.
-     - CRITICAL: bugs, data loss, security vulnerabilities
-     - HIGH: missing tests, broken error handling
-     - MEDIUM: style violations, missing docs for public APIs -->
+Reviews are scored 1–10 in each of the following categories. A total score ≥ 50 is required for approval.
+
+**Categories**: correctness, test coverage, error handling, performance, security, adherence to project conventions.
+
+Severity definitions for findings:
+
+- **CRITICAL**: Data corruption (e.g. wrong embeddings stored for a ticker), security vulnerabilities (SQL/command injection, leaked API keys), broken MCP protocol responses, panics in production code paths
+- **HIGH**: Missing tests for safety-critical paths (financial data accuracy, ingestion idempotency), unhandled errors from Qdrant or external APIs, N+1 query patterns against the vector DB
+- **MEDIUM**: Missing `clippy` fixes, undocumented public MCP tools, suboptimal chunking strategies, missing rate-limit handling for EDGAR/FRED
+- **LOW**: Minor style issues, test naming conventions, missing edge-case tests for non-critical helpers


### PR DESCRIPTION
## Summary
- Replace the hollow HTML-comment template in `examples/CLAUDE.md` with a fully filled-in example for an imaginary project: **findata-mcp**, a Rust MCP server for semantic Q&A over US company financials and macroeconomic data
- Covers all sections: project overview, implementation workflow, quality checks, E2E testing, environment variables, and code quality scoring rubric
- Gives users a concrete, realistic reference for how to populate their own `CLAUDE.md`

## Test plan
- [x] Verify all HTML template comments are replaced with concrete content
- [x] Verify internal consistency (ports, paths, env vars, commands all reference the same project)
- [x] Verify severity levels align with review workflow expectations (CRITICAL/HIGH/MEDIUM/LOW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)